### PR TITLE
use ransack method to prevent conflicts

### DIFF
--- a/lib/index_as_calendar/dsl.rb
+++ b/lib/index_as_calendar/dsl.rb
@@ -53,7 +53,7 @@ module IndexAsCalendar
           items = options[:model] || end_of_association_chain
           items = items.send(params[:scope]) if params[:scope].present?
           items = items.includes(options[:includes]) unless options[:includes].blank?
-          items = items.where(options[:start_date] => params[:start].to_date...params[:end].to_date).search(params[:q]).result
+          items = items.where(options[:start_date] => params[:start].to_date...params[:end].to_date).ransack(params[:q]).result
 
           events = event_mapping(items, options)
 


### PR DESCRIPTION
ActiveAdmin uses `ransack` method to prevent conflicts:
https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource_controller/data_access.rb#L216
For example, in my case it conflicts with `searchkick`